### PR TITLE
chore: Refactor structs + encapsulation

### DIFF
--- a/bot/handler.go
+++ b/bot/handler.go
@@ -3,7 +3,6 @@ package bot
 import (
 	"fmt"
 	"github.com/bwmarrin/discordgo"
-	"math/rand"
 	"strings"
 )
 
@@ -14,24 +13,26 @@ func (b Bot) messageHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 		return
 	}
 
-	if b.isAction(m) {
-		b.executeActions(s, m)
+	if b.isAction(m.Content) {
+		ba := BotActions{
+			bot: b,
+			log: b.log,
+			s:   s,
+			m:   m,
+		}
+		ba.executeActions()
 		return
 	}
 
 	if b.config.BotListening {
-		if m.Content == "" {
-			content, attachments, err := b.channelMessageLookup(s, m)
-			if err != nil {
-				b.log.ErrorLog(err.Error())
-				return
-			}
-
-			m.Content = content
-			m.Attachments = attachments
+		bm := BotMessages{
+			bot: b,
+			log: b.log,
+			s:   s,
+			m:   m,
 		}
 
-		err := b.messageSelector(s, m)
+		err := bm.messageSelector()
 		if err != nil {
 			b.log.ErrorLog(fmt.Sprintf("could not sent message: %s", err.Error()))
 		}
@@ -40,126 +41,6 @@ func (b Bot) messageHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 // isAction returns a boolean value validating if this is an action or not.
 // The message is considered an action if it has a "/" on the beginning.
-func (b Bot) isAction(m *discordgo.MessageCreate) bool {
-	return strings.HasPrefix(m.Content, "/")
-}
-
-// channelMessageLookup uses the channel id and message id to find the received message and read it's content.
-func (b Bot) channelMessageLookup(s *discordgo.Session, m *discordgo.MessageCreate) (string, []*discordgo.MessageAttachment, error) {
-	chanMsgs, err := s.ChannelMessages(m.ChannelID, 1, "", "", m.ID)
-	if err != nil {
-		b.log.ErrorLog(fmt.Sprintf("unable to get messages: %s", err))
-		return "", []*discordgo.MessageAttachment{}, err
-	}
-
-	return chanMsgs[0].Content, chanMsgs[0].Attachments, err
-}
-
-// messageSelector executes the 50-50 pseudo-randomized value to reply or not with a message for the received message on the channel.
-func (b Bot) messageSelector(s *discordgo.Session, m *discordgo.MessageCreate) error {
-	b.log.DebugLog(m.Author.Username)
-	b.log.DebugLog(fmt.Sprintf("found message on thread: %s", m.Content))
-
-	var err error
-	if rand.Intn(100) > 50 {
-		err = b.contentBasedInteraction(s, m)
-		if err != nil {
-			if err.Error() == "no_content_based_interaction_found" {
-				err = b.authorBasedInteraction(s, m)
-			}
-		}
-
-		if err != nil {
-			if err.Error() == "no_author_based_interaction_found" {
-				b.log.WarningLog("no message has been identified to be sent.")
-				return nil
-			}
-		}
-	}
-
-	return err
-}
-
-// contentBasedInteraction based on messages received sends a new different message, regardless of who is the author.
-func (b Bot) contentBasedInteraction(s *discordgo.Session, m *discordgo.MessageCreate) error {
-	if strings.Contains(strings.ToLower(m.Content), "cs") {
-		return b.csgoMessage(s, m)
-	}
-
-	if strings.Contains(strings.ToLower(m.Content), "pubg") {
-		return b.pubgMessage(s, m)
-	}
-
-	if strings.Contains(strings.ToLower(m.Content), "bora") ||
-		strings.Contains(strings.ToLower(m.Content), "online") ||
-		strings.Contains(strings.ToLower(m.Content), "vamo") ||
-		strings.Contains(strings.ToLower(m.Content), "voltei") {
-		return b.boraMessage(s, m)
-	}
-
-	if strings.Contains(strings.ToLower(m.Content), "gamersclub") {
-		return b.gamersclubMessage(s, m)
-	}
-
-	if strings.Contains(strings.ToLower(m.Content), "kim") {
-		return b.kimMessage(s, m)
-	}
-
-	if strings.Contains(strings.ToLower(m.Content), "schenk") || strings.Contains(strings.ToLower(m.Content), "marcel") {
-		return b.schenkMessage(s, m)
-	}
-
-	if strings.Contains(strings.ToLower(m.Content), "wolke") || strings.Contains(strings.ToLower(m.Content), "vitor") {
-		return b.vitorMentionedMessage(s, m)
-	}
-
-	if strings.Contains(strings.ToLower(m.Content), "bob") {
-		return b.bobMessage(s, m)
-	}
-
-	if strings.Contains(strings.ToLower(m.Content), "monstro") {
-		return b.monstroMessage(s, m)
-	}
-
-	if strings.Contains(strings.ToLower(m.Content), "hess") || strings.Contains(strings.ToLower(m.Content), "hsz") || strings.Contains(strings.ToLower(m.Content), "geferson") {
-		return b.hszMessage(s, m)
-	}
-
-	if strings.EqualFold(strings.ToLower(m.Content), "f") {
-		return b.fMessage(s, m)
-	}
-
-	b.log.WarningLog("no content based interactions found")
-	return fmt.Errorf("no_content_based_interaction_found")
-}
-
-// authorBasedInteraction based on who sent the message into the channel, replies back with some specific content.
-func (b Bot) authorBasedInteraction(s *discordgo.Session, m *discordgo.MessageCreate) error {
-	if strings.Contains(m.Author.Username, "chinela") {
-		return b.chinelaMessage(s, m)
-	}
-
-	if strings.Contains(m.Author.Username, "vitor") {
-		return b.vitorMessage(s, m)
-	}
-
-	if strings.Contains(m.Author.Username, "nico") {
-		return b.nicoMessage(s, m)
-	}
-
-	b.log.WarningLog("no author based interactions found")
-	return fmt.Errorf("no_author_based_interaction_found")
-}
-
-// executeActions identifies which command has been written by the member, and requests for the responsible function.
-func (b Bot) executeActions(s *discordgo.Session, m *discordgo.MessageCreate) {
-	if strings.ToLower(m.Content) == "/stop_listening" {
-		b.stopListening(m)
-	} else if strings.ToLower(m.Content) == "/start_listening" {
-		b.startListening(m)
-	} else if strings.HasPrefix(strings.ToLower(m.Content), "/play") {
-		b.callForGaming(s, m)
-	} else if strings.HasPrefix(strings.ToLower(m.Content), "/poll") {
-		b.startPoll(s, m)
-	}
+func (b Bot) isAction(message string) bool {
+	return strings.HasPrefix(message, "/")
 }

--- a/bot/messages.go
+++ b/bot/messages.go
@@ -4,76 +4,181 @@ import (
 	"fmt"
 	"github.com/bwmarrin/discordgo"
 	"math/rand"
+	"strings"
+	"stupid-bot/common"
 )
 
-func (b Bot) csgoMessage(s *discordgo.Session, m *discordgo.MessageCreate) error {
+type BotMessages struct {
+	bot Bot
+	log common.Logger
+	s   *discordgo.Session
+	m   *discordgo.MessageCreate
+}
+
+// messageSelector executes the 50-50 pseudo-randomized value to reply or not with a message for the received message on the channel.
+func (b BotMessages) messageSelector() error {
+	b.log.DebugLog(b.m.Author.Username)
+	b.log.DebugLog(fmt.Sprintf("found message on thread: %s", b.m.Content))
+
+	var err error
+	if rand.Intn(100) > 50 {
+		err = b.contentBasedInteraction()
+		if err != nil {
+			if err.Error() == "no_content_based_interaction_found" {
+				err = b.authorBasedInteraction()
+			}
+		}
+
+		if err != nil {
+			if err.Error() == "no_author_based_interaction_found" {
+				b.log.WarningLog("no message has been identified to be sent.")
+				return nil
+			}
+		}
+	}
+
+	return err
+}
+
+// contentBasedInteraction based on messages received sends a new different message, regardless of who is the author.
+func (b BotMessages) contentBasedInteraction() error {
+	if strings.Contains(strings.ToLower(b.m.Content), "cs") {
+		return b.csgoMessage()
+	}
+
+	if strings.Contains(strings.ToLower(b.m.Content), "pubg") {
+		return b.pubgMessage()
+	}
+
+	if strings.Contains(strings.ToLower(b.m.Content), "bora") ||
+		strings.Contains(strings.ToLower(b.m.Content), "online") ||
+		strings.Contains(strings.ToLower(b.m.Content), "vamo") ||
+		strings.Contains(strings.ToLower(b.m.Content), "voltei") {
+		return b.boraMessage()
+	}
+
+	if strings.Contains(strings.ToLower(b.m.Content), "gamersclub") {
+		return b.gamersclubMessage()
+	}
+
+	if strings.Contains(strings.ToLower(b.m.Content), "kim") {
+		return b.kimMessage()
+	}
+
+	if strings.Contains(strings.ToLower(b.m.Content), "schenk") || strings.Contains(strings.ToLower(b.m.Content), "marcel") {
+		return b.schenkMessage()
+	}
+
+	if strings.Contains(strings.ToLower(b.m.Content), "wolke") || strings.Contains(strings.ToLower(b.m.Content), "vitor") {
+		return b.vitorMentionedMessage()
+	}
+
+	if strings.Contains(strings.ToLower(b.m.Content), "bob") {
+		return b.bobMessage()
+	}
+
+	if strings.Contains(strings.ToLower(b.m.Content), "monstro") {
+		return b.monstroMessage()
+	}
+
+	if strings.Contains(strings.ToLower(b.m.Content), "hess") || strings.Contains(strings.ToLower(b.m.Content), "hsz") || strings.Contains(strings.ToLower(b.m.Content), "geferson") {
+		return b.hszMessage()
+	}
+
+	if strings.EqualFold(strings.ToLower(b.m.Content), "f") {
+		return b.fMessage()
+	}
+
+	b.log.WarningLog("no content based interactions found")
+	return fmt.Errorf("no_content_based_interaction_found")
+}
+
+// authorBasedInteraction based on who sent the message into the channel, reply back with some specific content.
+func (b BotMessages) authorBasedInteraction() error {
+	if strings.Contains(b.m.Author.Username, "chinela") {
+		return b.chinelaMessage()
+	}
+
+	if strings.Contains(b.m.Author.Username, "vitor") {
+		return b.vitorMessage()
+	}
+
+	if strings.Contains(b.m.Author.Username, "nico") {
+		return b.nicoMessage()
+	}
+
+	b.log.WarningLog("no author based interactions found")
+	return fmt.Errorf("no_author_based_interaction_found")
+}
+
+func (b BotMessages) csgoMessage() error {
 	message := "BORA JOGAR UM CSGO PORRA"
 	b.log.InfoLog(fmt.Sprintf("sending message: %s", message))
-	_, err := s.ChannelMessageSendReply(m.ChannelID, message, &discordgo.MessageReference{ChannelID: m.ChannelID, MessageID: m.Message.ID})
+	_, err := b.s.ChannelMessageSendReply(b.m.ChannelID, message, &discordgo.MessageReference{ChannelID: b.m.ChannelID, MessageID: b.m.Message.ID})
 	return err
 }
 
-func (b Bot) gamersclubMessage(s *discordgo.Session, m *discordgo.MessageCreate) error {
+func (b BotMessages) gamersclubMessage() error {
 	message := "try hard"
 	b.log.InfoLog(fmt.Sprintf("sending message: %s", message))
-	_, err := s.ChannelMessageSendReply(m.ChannelID, message, &discordgo.MessageReference{ChannelID: m.ChannelID, MessageID: m.Message.ID})
+	_, err := b.s.ChannelMessageSendReply(b.m.ChannelID, message, &discordgo.MessageReference{ChannelID: b.m.ChannelID, MessageID: b.m.Message.ID})
 	return err
 }
 
-func (b Bot) vitorMessage(s *discordgo.Session, m *discordgo.MessageCreate) error {
+func (b BotMessages) vitorMessage() error {
 	message := "baiter"
 	b.log.InfoLog(fmt.Sprintf("sending message: %s", message))
-	_, err := s.ChannelMessageSendReply(m.ChannelID, message, &discordgo.MessageReference{ChannelID: m.ChannelID, MessageID: m.Message.ID})
+	_, err := b.s.ChannelMessageSendReply(b.m.ChannelID, message, &discordgo.MessageReference{ChannelID: b.m.ChannelID, MessageID: b.m.Message.ID})
 	return err
 }
 
-func (b Bot) vitorMentionedMessage(s *discordgo.Session, m *discordgo.MessageCreate) error {
+func (b BotMessages) vitorMentionedMessage() error {
 	message := "esse ai nunca planta a bomba"
 	b.log.InfoLog(fmt.Sprintf("sending message: %s", message))
-	_, err := s.ChannelMessageSendReply(m.ChannelID, message, &discordgo.MessageReference{ChannelID: m.ChannelID, MessageID: m.Message.ID})
+	_, err := b.s.ChannelMessageSendReply(b.m.ChannelID, message, &discordgo.MessageReference{ChannelID: b.m.ChannelID, MessageID: b.m.Message.ID})
 	return err
 }
 
-func (b Bot) fMessage(s *discordgo.Session, m *discordgo.MessageCreate) error {
+func (b BotMessages) fMessage() error {
 	message := "https://tenor.com/view/keyboard-hyperx-rgb-hyperx-family-hyperx-gaming-gif-17743649"
 	b.log.InfoLog(fmt.Sprintf("sending message: %s", message))
-	_, err := s.ChannelMessageSendReply(m.ChannelID, message, &discordgo.MessageReference{ChannelID: m.ChannelID, MessageID: m.Message.ID})
+	_, err := b.s.ChannelMessageSendReply(b.m.ChannelID, message, &discordgo.MessageReference{ChannelID: b.m.ChannelID, MessageID: b.m.Message.ID})
 	return err
 }
 
-func (b Bot) bobMessage(s *discordgo.Session, m *discordgo.MessageCreate) error {
+func (b BotMessages) bobMessage() error {
 	message := "bob uma vez foi level 20 GC"
 	b.log.InfoLog(fmt.Sprintf("sending message: %s", message))
-	_, err := s.ChannelMessageSendReply(m.ChannelID, message, &discordgo.MessageReference{ChannelID: m.ChannelID, MessageID: m.Message.ID})
+	_, err := b.s.ChannelMessageSendReply(b.m.ChannelID, message, &discordgo.MessageReference{ChannelID: b.m.ChannelID, MessageID: b.m.Message.ID})
 	return err
 }
 
-func (b Bot) chinelaMessage(s *discordgo.Session, m *discordgo.MessageCreate) error {
+func (b BotMessages) chinelaMessage() error {
 	message := "De acordo com o leetify, chinela tem a maior taxa de amigos cegos por flash. Ótimo aproveitamento de utilitários."
 	b.log.InfoLog(fmt.Sprintf("sending message: %s", message))
-	_, err := s.ChannelMessageSendReply(m.ChannelID, message, &discordgo.MessageReference{ChannelID: m.ChannelID, MessageID: m.Message.ID})
+	_, err := b.s.ChannelMessageSendReply(b.m.ChannelID, message, &discordgo.MessageReference{ChannelID: b.m.ChannelID, MessageID: b.m.Message.ID})
 	return err
 }
 
-func (b Bot) monstroMessage(s *discordgo.Session, m *discordgo.MessageCreate) error {
+func (b BotMessages) monstroMessage() error {
 	message := "SAI DA JAULA"
 	b.log.InfoLog(fmt.Sprintf("sending message: %s", message))
-	_, err := s.ChannelMessageSend(m.ChannelID, message)
+	_, err := b.s.ChannelMessageSend(b.m.ChannelID, message)
 	return err
 }
 
-func (b Bot) hszMessage(s *discordgo.Session, m *discordgo.MessageCreate) error {
+func (b BotMessages) hszMessage() error {
 	message := "\"vou só levar um colchao na sogra, volto em 15 min\""
 	b.log.InfoLog(fmt.Sprintf("sending message: %s", message))
-	_, err := s.ChannelMessageSendReply(m.ChannelID, message, &discordgo.MessageReference{ChannelID: m.ChannelID, MessageID: m.Message.ID})
+	_, err := b.s.ChannelMessageSendReply(b.m.ChannelID, message, &discordgo.MessageReference{ChannelID: b.m.ChannelID, MessageID: b.m.Message.ID})
 	return err
 }
 
-func (b Bot) boraMessage(s *discordgo.Session, m *discordgo.MessageCreate) error {
+func (b BotMessages) boraMessage() error {
 	message := ""
 	max := 100
 	min := 1
-	randomNum := rand.Intn(max - min) + min
+	randomNum := rand.Intn(max-min) + min
 
 	if randomNum < 25 {
 		message = "csgo > valorant"
@@ -93,7 +198,7 @@ func (b Bot) boraMessage(s *discordgo.Session, m *discordgo.MessageCreate) error
 
 	if message != "" {
 		b.log.InfoLog(fmt.Sprintf("sending message: %s", message))
-		_, err := s.ChannelMessageSendReply(m.ChannelID, message, &discordgo.MessageReference{ChannelID: m.ChannelID, MessageID: m.Message.ID})
+		_, err := b.s.ChannelMessageSendReply(b.m.ChannelID, message, &discordgo.MessageReference{ChannelID: b.m.ChannelID, MessageID: b.m.Message.ID})
 		return err
 	}
 
@@ -101,30 +206,30 @@ func (b Bot) boraMessage(s *discordgo.Session, m *discordgo.MessageCreate) error
 	return nil
 }
 
-func (b Bot) nicoMessage(s *discordgo.Session, m *discordgo.MessageCreate) error {
+func (b BotMessages) nicoMessage() error {
 	message := "https://tenor.com/view/communiste-communist-hugs-heart-red-gif-14360509"
 	b.log.InfoLog(fmt.Sprintf("sending message: %s", message))
-	_, err := s.ChannelMessageSendReply(m.ChannelID, message, &discordgo.MessageReference{ChannelID: m.ChannelID, MessageID: m.Message.ID})
+	_, err := b.s.ChannelMessageSendReply(b.m.ChannelID, message, &discordgo.MessageReference{ChannelID: b.m.ChannelID, MessageID: b.m.Message.ID})
 	return err
 }
 
-func (b Bot) pubgMessage(s *discordgo.Session, m *discordgo.MessageCreate) error {
+func (b BotMessages) pubgMessage() error {
 	message := "jogo de nerdola"
 	b.log.InfoLog(fmt.Sprintf("sending message: %s", message))
-	_, err := s.ChannelMessageSendReply(m.ChannelID, message, &discordgo.MessageReference{ChannelID: m.ChannelID, MessageID: m.Message.ID})
+	_, err := b.s.ChannelMessageSendReply(b.m.ChannelID, message, &discordgo.MessageReference{ChannelID: b.m.ChannelID, MessageID: b.m.Message.ID})
 	return err
 }
 
-func (b Bot) kimMessage(s *discordgo.Session, m *discordgo.MessageCreate) error {
+func (b BotMessages) kimMessage() error {
 	message := "nosso muambeiro favorito"
 	b.log.InfoLog(fmt.Sprintf("sending message: %s", message))
-	_, err := s.ChannelMessageSendReply(m.ChannelID, message, &discordgo.MessageReference{ChannelID: m.ChannelID, MessageID: m.Message.ID})
+	_, err := b.s.ChannelMessageSendReply(b.m.ChannelID, message, &discordgo.MessageReference{ChannelID: b.m.ChannelID, MessageID: b.m.Message.ID})
 	return err
 }
 
-func (b Bot) schenkMessage(s *discordgo.Session, m *discordgo.MessageCreate) error {
+func (b BotMessages) schenkMessage() error {
 	message := "foi pra germania e nos esqueceu"
 	b.log.InfoLog(fmt.Sprintf("sending message: %s", message))
-	_, err := s.ChannelMessageSendReply(m.ChannelID, message, &discordgo.MessageReference{ChannelID: m.ChannelID, MessageID: m.Message.ID})
+	_, err := b.s.ChannelMessageSendReply(b.m.ChannelID, message, &discordgo.MessageReference{ChannelID: b.m.ChannelID, MessageID: b.m.Message.ID})
 	return err
 }


### PR DESCRIPTION
Refactor struts to be easier when adding new functions, messages and actions, so new functions do not require to receive arguments, and reduce how much down we are sending the same argument over, maintaining it only on the struct.

We now have three structs on the bot package:
````
Bot
BotActions
BotMessages
````